### PR TITLE
Throw underlying error

### DIFF
--- a/Sources/X3DH/X3DH.swift
+++ b/Sources/X3DH/X3DH.swift
@@ -4,7 +4,7 @@ import HKDF
 
 public typealias Signature = Data
 public typealias PrekeySigner = (PublicKey) throws -> Signature
-public typealias PrekeySignatureVerifier = (Signature) -> Bool
+public typealias PrekeySignatureVerifier = (Signature) throws -> Bool
 
 public class X3DH {
     let sodium = Sodium()
@@ -62,7 +62,7 @@ public class X3DH {
     }
 
     public func initiateKeyAgreement(remotePrekeyBundle: PrekeyBundle, prekeySignatureVerifier: PrekeySignatureVerifier, info: String) throws -> KeyAgreementInitiation {
-        guard prekeySignatureVerifier(remotePrekeyBundle.prekeySignature) else {
+        guard try prekeySignatureVerifier(remotePrekeyBundle.prekeySignature) else {
             throw X3DHError.invalidPrekeySignature
         }
 


### PR DESCRIPTION
This gives us the option to inspect and log the thrown error when verifying a prekey signature